### PR TITLE
Fix selector comparison

### DIFF
--- a/lib/css_compare/constants.rb
+++ b/lib/css_compare/constants.rb
@@ -1,5 +1,5 @@
 module CssCompare
   # The root directory of the Less2Sass source tree.
   ROOT_DIR = File.expand_path(File.join(__FILE__, '../../..'))
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/lib/css_compare/css/component/selector.rb
+++ b/lib/css_compare/css/component/selector.rb
@@ -16,11 +16,11 @@ module CssCompare
         # @return [Hash{String => Component::Property}] properties
         attr_accessor :properties
 
-        # @param [String] name of the selector
+        # @param [String] name the selector's name
         # @param [Array<Sass::Tree::PropNode>] properties to be included
         # @param [Array<String>] conditions @media query conditions
         def initialize(name, properties, conditions)
-          @name = name
+          @name = name.strip
           @properties = {}
           process_properties(properties, conditions)
         end
@@ -80,7 +80,7 @@ module CssCompare
         # @return [Selector] a copy of self
         def deep_copy(name = @name)
           copy = dup
-          copy.name = name
+          copy.name = name.strip
           copy.properties = {}
           @properties.each { |k, v| copy.properties[k] = v.deep_copy }
           copy

--- a/lib/css_compare/css/engine.rb
+++ b/lib/css_compare/css/engine.rb
@@ -88,8 +88,7 @@ module CssCompare
       # @param [Engine] other the engine to compare this with.
       # @return [Boolean]
       def ==(other)
-        keys = @engine.keys + other.engine.keys
-        return false unless keys.uniq! # @todo this won't work
+        keys = @engine.keys
         keys.all? { |key| @engine[key] == other.engine[key] }
       end
 


### PR DESCRIPTION
Fix failing comparison of equal selectors with white-spacing differences. Example:
```css
/* file1.css */
.banner, #id {
    display: none; }
```
Additional whitespace:
```css
/* file2.css */
.banner,
#id {
    display: none;
}
```