### PR TITLE
String value normalization

### DIFF
--- a/lib/css_compare/constants.rb
+++ b/lib/css_compare/constants.rb
@@ -1,5 +1,5 @@
 module CssCompare
   # The root directory of the Less2Sass source tree.
   ROOT_DIR = File.expand_path(File.join(__FILE__, '../../..'))
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
Sanitizes string values by normalizing the quotes within the string.
Examples (like #to_s was applied):
```
"'path/to/file.css'" #=> "path/to/file.css"
""path/\"to the\"/file.css"" #=> "path/"to the"/file.css"
```

Normalizes relative paths in url values.
Example:
```
url("./path/to/file.css") #=> url("path/to/file.css")
```