### PR TITLE
AST-based value comparison

### DIFF
--- a/css_compare.gemspec
+++ b/css_compare.gemspec
@@ -34,6 +34,7 @@ CSSCOMPARE_GEMSPEC = Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'sass', '~> 3.4'
+  spec.add_dependency 'color', '~> 1.8'
 
   spec.add_development_dependency 'rake', '~> 11.1'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/css_compare/constants.rb
+++ b/lib/css_compare/constants.rb
@@ -1,5 +1,5 @@
 module CssCompare
   # The root directory of the Less2Sass source tree.
   ROOT_DIR = File.expand_path(File.join(__FILE__, '../../..'))
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/lib/css_compare/css.rb
+++ b/lib/css_compare/css.rb
@@ -1,3 +1,4 @@
+require 'css_compare/css/value_factory'
 require 'css_compare/css/component'
 require 'css_compare/css/parser'
 require 'css_compare/css/engine'

--- a/lib/css_compare/css/component/base.rb
+++ b/lib/css_compare/css/component/base.rb
@@ -11,9 +11,20 @@ module CssCompare
         # @param [Hash] that second hash to compare
         # @return [Boolean]
         def ==(this, that)
-          keys = this.keys + that.keys
-          keys.uniq!
+          keys = merge_keys(this, that)
           keys.all? { |key| this[key] && that[key] && this[key] == that[key] }
+        end
+
+        def equals?(this, that)
+          keys = merge_keys(this, that)
+          keys.all? { |key| this[key] && that[key] && this[key].equals?(that[key]) }
+        end
+
+        private
+
+        def merge_keys(this, that)
+          keys = this.keys + that.keys
+          keys.uniq
         end
       end
     end

--- a/lib/css_compare/css/component/property.rb
+++ b/lib/css_compare/css/component/property.rb
@@ -28,7 +28,7 @@ module CssCompare
         def initialize(node, conditions)
           @name = node.resolved_name
           @values = {}
-          value = Value.new(node.resolved_value)
+          value = Value.new(node)
           conditions.each { |c| set_value(value.clone, c) }
         end
 

--- a/lib/css_compare/css/component/property.rb
+++ b/lib/css_compare/css/component/property.rb
@@ -42,7 +42,8 @@ module CssCompare
         #   with.
         # @return [Boolean]
         def ==(other)
-          super(@values, other.values)
+          return super(@values, other.values) unless font?
+          equals?(@values, other.values)
         end
 
         # Merges the property with another one.
@@ -139,6 +140,10 @@ module CssCompare
         # @return [Boolean]
         def important_value?(val)
           val.to_s.include?('!important')
+        end
+
+        def font?
+          @name['font']
         end
 
         # Breaks down complex properties like `border` into

--- a/lib/css_compare/css/component/value.rb
+++ b/lib/css_compare/css/component/value.rb
@@ -4,10 +4,10 @@ module CssCompare
       # Represents the value of a CSS property under
       # certain conditions declared by @media queries.
       class Value < Base
-        # @return [#to_s]
+        # @return [CssCompare::CSS::Value::Base]
         attr_accessor :value
 
-        # @param [#to_s] val the value of the property
+        # @param [Sass::Tree::PropNode] val the value of the property
         def initialize(val)
           self.value = val
         end
@@ -16,23 +16,21 @@ module CssCompare
         # Equal values mean, that the actual value and
         # the importance, as well, are set equally.
         #
-        # @param [Value] other the value to compare this with
+        # @param [CssCompare::CSS::Value::Base] other the value to compare this with
         # @return [Boolean]
         def ==(other)
-          @value.to_s == other.value.to_s
+          @value == other.value
         end
 
-        # Sets the value and the importance of
-        # the {Value} node.
-        #
         # @private
-        def value=(value)
-          original_value = value = value.is_a?(Value) ? value.value : value
-          # Can't do gsub! because the String gets frozen and can't be further modified by strip
-          value = value.gsub(/\s*!important\s*/, '')
-          @is_important = value != original_value
-          value = sanitize_value(value) if value =~ CONTAIN_STRING
-          @value = value
+        def value=(val)
+          if val.is_a?(self.class)
+            @is_important = val.important?
+            @value = val.value
+          else
+            @value = ValueFactory.create(val.value)
+            @is_important = @value.important?
+          end
         end
 
         # Tells, whether or not the value is marked as !important
@@ -44,32 +42,7 @@ module CssCompare
 
         # @return [String] the String representation of this node
         def to_s
-          @value.to_s + (@is_important ? ' !important' : '')
-        end
-
-        private
-
-        CONTAIN_STRING = /['"](.*)['"]/
-
-        # Normalizes string values.
-        #
-        # We can assume, that a value describes a path
-        # if following the removal of leading and trailing
-        # quotes it begins with a `./`. It can be safely
-        # removed without affecting the real value of
-        # the CSS property.
-        #
-        # Examples:
-        #   "'path/to/file.css'" #=> "path/to/file.css"
-        #   ""\"path/to/file.css\""" #=> ""path/to/file.css""
-        #   "./path/to/file.css" #=> "path/to/file.css"
-        #
-        # @param [String] value the string to sanitize
-        # @return [String] sanitized string
-        def sanitize_value(value)
-          value = value.sub(/\A['"](.*)['"]\Z/, '\1').gsub(/\\"|"|'/, '"') # Solves first two examples
-          value = value.sub('./', '') if value.start_with?('url(') # Solves third if it's a url value
-          value
+          @value.to_s
         end
       end
     end

--- a/lib/css_compare/css/component/value.rb
+++ b/lib/css_compare/css/component/value.rb
@@ -22,6 +22,10 @@ module CssCompare
           @value == other.value
         end
 
+        def equals?(other)
+          @value.equals?(other.value)
+        end
+
         # @private
         def value=(val)
           if val.is_a?(self.class)

--- a/lib/css_compare/css/engine.rb
+++ b/lib/css_compare/css/engine.rb
@@ -278,7 +278,7 @@ module CssCompare
       #   a small change in the the selector's name.
       #
       # @param [Sass::Tree:RuleNode] node the Rule node
-      # @param [Array<String>] parent_query_list processed parent_query_list of the
+      # @param [Array<String>] conditions processed parent_query_list of the
       #   parent media node. If the rule is global, it will be assigned
       #   to the media query equal to `@media all {}`.
       # @return [Void]

--- a/lib/css_compare/css/engine.rb
+++ b/lib/css_compare/css/engine.rb
@@ -54,6 +54,9 @@ module CssCompare
       attr_accessor :selectors, :keyframes, :namespaces,
                     :pages, :supports, :charset
 
+      # @note UTF-8 is assumed as default charset
+      # @see https://www.w3.org/TR/CSS2/syndata.html#x52
+      #
       # @param [String, Sass::Tree::Node] input the source file of
       #   the CSS project, or its AST
       def initialize(input)
@@ -76,7 +79,7 @@ module CssCompare
         @pages = {}
         @supports = {}
         @unsupported = []
-        @charset
+        @charset = 'UTF-8'
       end
 
       # Checks, whether two engines are equal.

--- a/lib/css_compare/css/value/base.rb
+++ b/lib/css_compare/css/value/base.rb
@@ -1,3 +1,5 @@
+require 'color'
+
 module CssCompare
   module CSS
     module Value
@@ -18,11 +20,23 @@ module CssCompare
           self.class == other.class
         end
 
-        # Checks, whether the CSS values are flagged as !important
+        def equals?(other)
+          self == other
+        end
+
+        # Checks, whether the CSS values are flagged as !important.
         #
         # @return [Boolean]
         def important?
           @value.to_sass.include?('!important')
+        end
+
+        # Checks, whether the CSS value is a color. Subclasses may
+        # override this method.
+        #
+        # @return [Boolean]
+        def color?
+          false
         end
 
         # @return [String]
@@ -38,6 +52,10 @@ module CssCompare
         # @return [String] sanitized string
         def sanitize_string(value)
           value.sub(/\A['"](.*)['"]\Z/, '\1').gsub(/\\"|"|'/, '"')
+        end
+
+        def sanitize_font(value)
+          value.gsub(/\\"|"|'/, '')
         end
 
         # Normalizes the url paths.

--- a/lib/css_compare/css/value/base.rb
+++ b/lib/css_compare/css/value/base.rb
@@ -1,0 +1,66 @@
+module CssCompare
+  module CSS
+    module Value
+      # The base class for wrapping the CSS property values
+      class Base
+        # @return [Sass::Script::Tree::Node]
+        attr_accessor :value
+
+        # @param [Sass::Script::Tree::Node] value the SassScript value to be wrapped
+        def initialize(value)
+          @value = value
+        end
+
+        # Checks, whether the CSS values are equal
+        #
+        # @return [Boolean]
+        def ==(other)
+          self.class == other.class
+        end
+
+        # Checks, whether the CSS values are flagged as !important
+        #
+        # @return [Boolean]
+        def important?
+          @value.to_sass.include?('!important')
+        end
+
+        # @return [String]
+        def to_s
+          @value.to_sass
+        end
+
+        protected
+
+        # Normalizes the quoted string values.
+        #
+        # @param [String] value the string to sanitize
+        # @return [String] sanitized string
+        def sanitize_string(value)
+          value.sub(/\A['"](.*)['"]\Z/, '\1').gsub(/\\"|"|'/, '"')
+        end
+
+        # Normalizes the url paths.
+        #
+        # We can assume, that a value describes a path
+        # if following the removal of leading and trailing
+        # quotes it begins with a `./`. It can be safely
+        # removed without affecting the real value of
+        # the CSS property.
+        #
+        # Examples:
+        #   "'path/to/file.css'" #=> "path/to/file.css"
+        #   ""\"path/to/file.css\""" #=> ""path/to/file.css""
+        #   "./path/to/file.css" #=> "path/to/file.css"
+        #
+        # @param [String] value the url path to normalize
+        # @return [String] the normalized path
+        def sanitize_url(value)
+          value = sanitize_string(value)
+          value = value.sub('./', '') if value.start_with?('./')
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/css_compare/css/value/function.rb
+++ b/lib/css_compare/css/value/function.rb
@@ -1,0 +1,26 @@
+module CssCompare
+  module CSS
+    module Value
+      # Wraps the SassScript Funcall object
+      class Function < Base
+
+        # Checks, whether two function expressions are equal.
+        #
+        # @param [Function] other the other function expression
+        # @return [Boolean]
+        def ==(other)
+          return false unless super
+          arg1 = @value.args.length
+          arg2 = other.value.args.length
+          return false unless arg1 == arg2
+          @value.args.each_index do |i|
+            value1 = @value.args[i].value.to_sass
+            value2 = other.value.args[i].value.to_sass
+            return false unless value1 == value2
+          end
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/css_compare/css/value/function.rb
+++ b/lib/css_compare/css/value/function.rb
@@ -9,16 +9,55 @@ module CssCompare
         # @param [Function] other the other function expression
         # @return [Boolean]
         def ==(other)
-          return false unless super
-          arg1 = @value.args.length
-          arg2 = other.value.args.length
-          return false unless arg1 == arg2
-          @value.args.each_index do |i|
-            value1 = @value.args[i].value.to_sass
-            value2 = other.value.args[i].value.to_sass
-            return false unless value1 == value2
+          if color?
+            return false unless other.color?
+            ::Color.equivalent?(color, other.color)
+          else
+            return false unless super
+            arg1 = @value.args.length
+            arg2 = other.value.args.length
+            return false unless arg1 == arg2
+            args1 = @value.args.collect { |x| ValueFactory.create(x) }
+            args2 = other.value.args.collect { |x| ValueFactory.create(x) }
+            args1.each_index { |i| args1[i] == args2[i] }
           end
-          true
+        end
+
+        # @see Base#color?
+        def color?
+          rgb? || hsl?
+        end
+
+        def color
+          raise StandardError, 'Function not a color' unless color?
+          args = @value.args.collect { |x| x.value.value }
+          if rgb?
+            ::Color::RGB.new(args[0], args[1], args[2])
+          elsif hsl?
+            ::Color::HSL.new(args[0], args[1], args[2])
+          end
+        end
+
+        def alpha?
+          @value.args.length == 4
+        end
+
+        def alpha
+          return @value.args[3] if alpha?
+          false
+        end
+
+        private
+
+        RGB_COLOR_FUNCTIONS = %w(rgb rgba)
+        HSL_COLOR_FUNCTIONS = %w(hsl hsla)
+
+        def rgb?
+          RGB_COLOR_FUNCTIONS.include?(@value.name)
+        end
+
+        def hsl?
+          HSL_COLOR_FUNCTIONS.include?(@value.name)
         end
       end
     end

--- a/lib/css_compare/css/value/list_literal.rb
+++ b/lib/css_compare/css/value/list_literal.rb
@@ -1,0 +1,26 @@
+module CssCompare
+  module CSS
+    module Value
+      # Wraps the SassScript ListLiteral object.
+      class ListLiteral < Base
+
+        # Checks, whether two list literals are equal.
+        #
+        # @param [ListLiteral] other the other list literal
+        # @return [Boolean]
+        def ==(other)
+          return false unless super
+          elements1 = @value.elements.length
+          elements2 = other.value.elements.length
+          return false unless elements1 == elements2
+          @value.elements.each_index do |i|
+            value1 = sanitize_string(@value.elements[i].to_sass)
+            value2 = sanitize_string(other.value.elements[i].to_sass)
+            return false unless value1 == value2
+          end
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/css_compare/css/value/literal.rb
+++ b/lib/css_compare/css/value/literal.rb
@@ -1,0 +1,20 @@
+module CssCompare
+  module CSS
+    module Value
+      # Wraps the SassScript Literal object.
+      class Literal < Base
+
+        # Checks, whether two literals are equal.
+        #
+        # @param [Literal] other the other literal
+        # @return [Boolean]
+        def ==(other)
+          return false unless super
+          value1 = sanitize_string(@value.to_sass)
+          value2 = sanitize_string(other.value.to_sass)
+          value1 == value2
+        end
+      end
+    end
+  end
+end

--- a/lib/css_compare/css/value/literal.rb
+++ b/lib/css_compare/css/value/literal.rb
@@ -9,10 +9,48 @@ module CssCompare
         # @param [Literal] other the other literal
         # @return [Boolean]
         def ==(other)
-          return false unless super
-          value1 = sanitize_string(@value.to_sass)
-          value2 = sanitize_string(other.value.to_sass)
+          if color?
+            return false unless other.color?
+            ::Color.equivalent?(color, other.color)
+          else
+            return false unless super
+            value1 = sanitize_string(@value.to_sass)
+            value2 = sanitize_string(other.value.to_sass)
+            value1 == value2
+          end
+        end
+
+        def equals?(other)
+          value1 = sanitize_font(@value.to_sass)
+          value2 = sanitize_font(other.value.to_sass)
           value1 == value2
+        end
+
+        def color?
+          named_color? || hex_color?
+        end
+
+        def color
+          return nil unless color?
+          hex_color? ? hex_color : named_color
+        end
+
+        private
+
+        HEX_COLOR_LITERAL = /^#(?:[a-f0-9]{3}){1,2}$/i
+
+        def named_color?
+          ::Color::CSS[@value.to_sass]
+        end
+
+        alias_method :named_color, :named_color?
+
+        def hex_color?
+          @value.to_sass =~ HEX_COLOR_LITERAL
+        end
+
+        def hex_color
+          ::Color::RGB.by_hex(@value.to_sass)
         end
       end
     end

--- a/lib/css_compare/css/value/url.rb
+++ b/lib/css_compare/css/value/url.rb
@@ -1,0 +1,20 @@
+module CssCompare
+  module CSS
+    module Value
+      # Wraps the SassScript `url` Funcall.
+      class Url < Base
+
+        # Checks, whether two url calls are equal.
+        #
+        # @param [Url] other the other url call
+        # @return [Boolean]
+        def ==(other)
+          return false unless super
+          value1 = sanitize_url(@value.args[0].value.value)
+          value2 = sanitize_url(other.value.args[0].value.value)
+          value1 == value2
+        end
+      end
+    end
+  end
+end

--- a/lib/css_compare/css/value_factory.rb
+++ b/lib/css_compare/css/value_factory.rb
@@ -1,0 +1,29 @@
+require 'css_compare/css/value/base'
+require 'css_compare/css/value/literal'
+require 'css_compare/css/value/list_literal'
+require 'css_compare/css/value/function'
+require 'css_compare/css/value/url'
+
+module CssCompare
+  module CSS
+    module ValueFactory
+
+      # Creates the value object by applying the appropriate wrapper class.
+      #
+      # @param [Sass::Script::Tree::Node] value the CSS property's value
+      # @return [CssCompare::CSS::Value::Base] the wrapped property value
+      def self.create(value)
+        if value.is_a?(Sass::Script::Tree::Literal)
+          Value::Literal.new(value)
+        elsif value.is_a?(Sass::Script::Tree::ListLiteral)
+          Value::ListLiteral.new(value)
+        elsif value.is_a?(Sass::Script::Tree::Funcall)
+          return Value::Function.new(value) unless value.name == 'url'
+          Value::Url.new(value)
+        else
+          raise StandardError, 'Unsupported type of CSS value'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces the stringified value comparison method with an AST-based one. It should make different types of values easier to compare.
There are CSS properties like _font-family_, where it does not matter whether the value is enclosed in quotes or not. Further on, function arguments split by commas can have several whitespace characters between each other, etc.
Using the new implementation, it shall be easier to normalize and compare such CSS values.

EDIT: Added support for:
- color value comparison (red == #ff0000 == rgb(255,0,0)),
- font-family name values ("Open Sans Condensed" == Open Sans Condensed)
